### PR TITLE
Add options page to choose folder

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,5 +10,6 @@
   },
   "background": {
     "service_worker": "background.js"
-  }
+  },
+  "options_page": "options.html"
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Options - Chrome Links</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 10px; }
+    #status { margin-top: 10px; color: green; }
+  </style>
+</head>
+<body>
+  <h1>Select Folder to Share</h1>
+  <select id="folderSelect"></select>
+  <button id="saveBtn">Save</button>
+  <div id="status"></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,34 @@
+function traverse(nodes, depth = 0) {
+  const select = document.getElementById('folderSelect');
+  nodes.forEach(node => {
+    if (!node.url) { // folder
+      const option = document.createElement('option');
+      option.value = node.id;
+      option.textContent = '--'.repeat(depth) + ' ' + node.title;
+      select.appendChild(option);
+      if (node.children) {
+        traverse(node.children, depth + 1);
+      }
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  chrome.bookmarks.getTree((nodes) => {
+    traverse(nodes);
+    chrome.storage.sync.get('sharedFolderId', (data) => {
+      if (data.sharedFolderId) {
+        document.getElementById('folderSelect').value = data.sharedFolderId;
+      }
+    });
+  });
+
+  document.getElementById('saveBtn').addEventListener('click', () => {
+    const selectedId = document.getElementById('folderSelect').value;
+    chrome.storage.sync.set({ sharedFolderId: selectedId }, () => {
+      const status = document.getElementById('status');
+      status.textContent = 'Folder saved.';
+      setTimeout(() => { status.textContent = ''; }, 1000);
+    });
+  });
+});

--- a/popup.html
+++ b/popup.html
@@ -9,5 +9,6 @@
 <body>
   <h1>Hello</h1>
   <p>This is a simple popup for the extension.</p>
+  <p><a href="options.html" target="_blank">Options</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `options_page` entry in `manifest.json`
- expose options link from popup
- create options page to list bookmark folders and save choice

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840d25b90a8832191b1a865400ded33